### PR TITLE
chore: README cleanup (remove stats/stargazers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -806,4 +806,3 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## 🌟 Stargazers
 
-[![Stargazers repo roster for @muhittincamdali/iOSTestingTools](https://starchart.cc/muhittincamdali/iOSTestingTools.svg)](https://github.com/muhittincamdali/iOSTestingTools/stargazers) 


### PR DESCRIPTION
Removes analytics/stargazers sections to keep README focused.