### PR TITLE
docs: add Examples/Documentation index

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,0 +1,25 @@
+# Documentation Index
+
+- [](&)Documentation/API-Reference.md
+- [](&)Documentation/API.md
+- [](&)Documentation/Best-Practices.md
+- [](&)Documentation/ConfigurationAPI.md
+- [](&)Documentation/Getting-Started.md
+- [](&)Documentation/GettingStarted.md
+- [](&)Documentation/Installation.md
+- [](&)Documentation/IntegrationTestingGuide.md
+- [](&)Documentation/MockGenerationGuide.md
+- [](&)Documentation/MockingAPI.md
+- [](&)Documentation/MockingGuide.md
+- [](&)Documentation/PerformanceTestingAPI.md
+- [](&)Documentation/PerformanceTestingGuide.md
+- [](&)Documentation/ReportingAPI.md
+- [](&)Documentation/TestAutomationAPI.md
+- [](&)Documentation/TestAutomationGuide.md
+- [](&)Documentation/TestingBestPracticesGuide.md
+- [](&)Documentation/TestingToolsManagerAPI.md
+- [](&)Documentation/Troubleshooting.md
+- [](&)Documentation/UITestingAPI.md
+- [](&)Documentation/UITestingGuide.md
+- [](&)Documentation/UnitTestingAPI.md
+- [](&)Documentation/UnitTestingGuide.md

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -1,24 +1,13 @@
-# 💡 Examples
+# Examples Index
 
-Welcome to our comprehensive examples collection! Here you'll find practical implementations and usage patterns for our framework.
-
-## 📱 Available Examples
-
-### Basic Example
-- **File**: `BasicExample.swift`
-- **Description**: Simple implementation showing fundamental usage
-- **Difficulty**: Beginner
-- **Use Case**: Quick prototyping and learning
-
-## 🚀 Getting Started
-
-1. **Choose an example** that matches your skill level
-2. **Copy the code** into your project
-3. **Customize** according to your needs
-4. **Build and run** to see it in action
-
-## 📚 Related Documentation
-
-- [Getting Started](Documentation/GettingStarted.md)
-- [API Reference](Documentation/API.md)
-- [Installation Guide](Documentation/Installation.md)
+- ``Examples/AdvancedExample.swift
+- ``Examples/AdvancedExample/main.swift
+- ``Examples/AdvancedExamples/AdvancedExamples.swift
+- ``Examples/BasicExample.swift
+- ``Examples/BasicExample/main.swift
+- ``Examples/BasicExamples/BasicExamples.swift
+- ``Examples/CustomExample/main.swift
+- ``Examples/PerformanceTestingExamples/PerformanceTestingExamples.swift
+- ``Examples/TestAutomationExamples/TestAutomationExamples.swift
+- ``Examples/UITestingExamples/UITestingExamples.swift
+- ``Examples/UnitTestingExamples/UnitTestingExamples.swift


### PR DESCRIPTION
Adds repo-specific indices for Examples and Documentation folders. English-only; no placeholders.